### PR TITLE
FIXED 2 issues

### DIFF
--- a/src/Peekmo/JsonPath/JsonPath.php
+++ b/src/Peekmo/JsonPath/JsonPath.php
@@ -151,7 +151,7 @@ class JsonPath
     * @param string $x filter
     * @param array  $v node
     * */
-    private function evalx($x, $v, $vname) 
+    private function evalx($x, $v, $vname=null) 
     {
         $name = "";
         $o = $this->toObject($v);
@@ -169,7 +169,8 @@ class JsonPath
 
     private function toObject($array)
     {
-        $o = (object)'';
+        //$o = (object)'';
+        $o = new stdClass();
 
         foreach ($array as $key => $value) {
             if (is_array($value)) {


### PR DESCRIPTION
1. evalx expecting 3rd parameter (and never using it) - added default null value
2. toObject method was flooding hierarchy with empty scalars - now it is using stdClass
