### PR TITLE
Fix. for strict warnings.

### DIFF
--- a/src/Peekmo/JsonPath/JsonStore.php
+++ b/src/Peekmo/JsonPath/JsonStore.php
@@ -135,7 +135,8 @@ class JsonStore
      */
     function set($expr, $value)
     {
-        if ($res =& $this->get($expr)) {
+        $get = $this->get($expr);
+        if ($res =& $get) {
             foreach ($res as &$r) {
                 $r = $value;
             }
@@ -155,7 +156,8 @@ class JsonStore
      */
     public function add($parentexpr, $value, $name = "")
     {
-        if ($parents =& $this->get($parentexpr)) {
+        $get = $this->get($parentexpr);
+        if ($parents =& $get) {
 
             foreach ($parents as &$parent) {
                 $parent = is_array($parent) ? $parent : array();


### PR DESCRIPTION
When trying to use JsonStore::set or JsonStore::add, I end up getting strict warnings (with E_STRICT enable in my php.ini configuration).

`Strict standards: Only variables should be assigned by reference in ./src/Peekmo/JsonPath/JsonStore.php on line 158`

I think that we shouldn't be using syntax like this:

```php
if ($res =& $this->get($expr)) {
```

Something like this:

```php
$x = $this->get($expr);
if ($res =& $x) {
```

---

PHP 5.5.9-1ubuntu4.5 (cli) (built: Oct 29 2014 11:59:10) 
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.3, Copyright (c) 1999-2014, by Zend Technologies
    with Xdebug v2.2.3, Copyright (c) 2002-2013, by Derick Rethans