### PR TITLE
fix use of undefined constant evaluating expression

### DIFF
--- a/src/Peekmo/JsonPath/JsonPath.php
+++ b/src/Peekmo/JsonPath/JsonPath.php
@@ -230,6 +230,8 @@ class JsonPath
     {
         $name = "";
         $expr = preg_replace(array("/\\$/", "/@/"), array("\$this->obj", "\$v"), $x);
+        $expr = preg_replace("#\[([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)\]#", "['$1']", $expr);
+        
         $res = eval("\$name = $expr;");
 
         if ($res === false) {


### PR DESCRIPTION
This minor fix prevents PHP Notice "Use of undefined constant FOO - assumed 'FOO'" when eval "$name = $v[FOO]"
