### PR TITLE
Expression rule for current node and fix getting unique nodes

### DIFF
--- a/src/Peekmo/JsonPath/JsonPath.php
+++ b/src/Peekmo/JsonPath/JsonPath.php
@@ -164,6 +164,9 @@ class JsonPath
                 $this->trace($this->evalx($loc, $val, substr($path, strrpos($path, ";") + 1)) . ";" . $x, $val, $path);
             }
             else if (preg_match("/^\?\(.*?\)$/", $loc)) { // [?(expr)]
+	            if ($this->evalx(preg_replace("/^\?\((.*?)\)$/", "$1", $loc), $val)) {
+		            $this->trace($x, $val, $path);
+	            }
                 $this->walk($loc, $x, $val, $path, array(&$this, "_callback_05"));
             }
             else if (preg_match("/^(-?[0-9]*):(-?[0-9]*):?(-?[0-9]*)$/", $loc)) { // [start:end:step]  phyton slice syntax

--- a/src/Peekmo/JsonPath/JsonStore.php
+++ b/src/Peekmo/JsonPath/JsonStore.php
@@ -106,16 +106,13 @@ class JsonStore
 
             if (true === $unique) {
                 if (!empty($values) && is_array($values[0])) {
-                    array_walk($values, function(&$value) {
-                        $value = json_encode($value);
-                    });
-
-                    $values = array_unique($values);
-                    array_walk($values, function(&$value) {
-                        $value = json_decode($value, true);
-                    });
-
-                    return array_values($values);
+	                $tmpValues = array_map(function($value) {
+                        return json_encode($value);
+                    }, $values);
+	
+	                $tmpValues = array_unique($tmpValues);
+	                
+                    return array_values(array_intersect_key($values, $tmpValues));
                 }
 
                 return array_unique($values);


### PR DESCRIPTION
Rules with expressions allow select nodes by name and content in Jayway JsonPath implementation. for example: 

```JSON
[
 { "a": { "c": 1, "d": 1 }, "b": { "c": 1, "d": 2 } },
 { "a": { "c": 2, "d": 3 }, "b": { "c": 2, "d": 4 } }
]
```

rule `$..a[?(@.c==2)]` selects

```JSON
[ { "c" : 2, "d" : 3 } ]
```

This changes add similar behavior and allow getting unique nodes with values by references. The following code becomes valid:

```PHP
$jsonStore = new JsonStore([
 [ "a"=>[ "c"=>1, "d"=>1 ], "b"=>[ "c"=>1, "d"=>2 ] ],
 [ "a"=>[ "c"=>2, "d"=>3 ], "b"=>[ "c"=>2, "d"=>4 ] ]
]);
// set "d" to 5 only for "a" node witch field "c" equivalent 2
$jsonStore->get('$..a[?(@.c==2)]', true)[0]['d'] = 5;
```